### PR TITLE
fix: use force checkout to handle dirty working directory

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -60,7 +60,7 @@ runs:
           run: |
               git fetch origin ${{ github.event.pull_request.base.ref }}
               git fetch origin ${{ github.event.pull_request.head.ref }}
-              git checkout ${{ github.event.pull_request.head.sha }}
+              git checkout -f ${{ github.event.pull_request.head.sha }}
 
         - name: Check coverage
           if: github.event_name == 'pull_request' && (inputs.diff-lines-threshold == 0 || steps.check-lines.outputs.skip-coverage != 'true')


### PR DESCRIPTION
## Summary

The `git checkout` on line 63 of `action.yml` fails when a consuming workflow modifies files before invoking this action (e.g. `yarn install` updates `yarn.lock`). Git refuses to overwrite dirty tracked files.

**Error from CI:**
```
error: Your local changes to the following files would be overwritten by checkout:
    yarn.lock
Please commit your changes or stash them before you switch branches.
Aborting
```

This cascades: `diff-cover` never runs → `coverage-report.txt` is never created → the `sed` and `github-script` steps also fail.

**Fix:** Add `-f` flag to `git checkout` so it discards irrelevant local modifications (build artifacts, lockfile changes) before switching to the PR head SHA.

## Review & Testing Checklist for Human

- [ ] Verify the `-f` flag doesn't cause issues for other repos consuming this action (force checkout discards uncommitted changes — confirm this is acceptable since we only need the source tree at the PR head SHA for `diff-cover`)
- [ ] Re-run the failing CI job in `candidate-backend` after merging to confirm the fix: https://github.com/doctariDev/candidate-backend/actions/runs/26451941824/job/77876051854

### Notes

The one-character change (`git checkout` → `git checkout -f`) is intentionally minimal. The local modifications discarded are artifacts of prior workflow steps (like `yarn install`) and are irrelevant to the coverage diff calculation.

Link to Devin session: https://app.devin.ai/sessions/92af84e6f09e41ec8067c58c26aa354c
Requested by: @kkhaidukov