### PR TITLE
fix: remove unnecessary head branch fetch and checkout

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -59,8 +59,6 @@ runs:
           shell: bash
           run: |
               git fetch origin ${{ github.event.pull_request.base.ref }}
-              git fetch origin ${{ github.event.pull_request.head.ref }}
-              git checkout ${{ github.event.pull_request.head.sha }}
 
         - name: Check coverage
           if: github.event_name == 'pull_request' && (inputs.diff-lines-threshold == 0 || steps.check-lines.outputs.skip-coverage != 'true')


### PR DESCRIPTION
## Summary

Follow-up to #4. The previous fix (`git checkout -f`) resolved the dirty working directory issue, but now `git fetch origin $HEAD_REF` fails when the PR branch has been deleted from the remote:

```
fatal: couldn't find remote ref ddd8
```

Both the `git fetch origin $HEAD_REF` and `git checkout` lines are unnecessary:
- The consuming workflow uses `actions/checkout@v4` with `fetch-depth: 0`, which already fetches full history including the PR head SHA
- We're already on the correct commit after `actions/checkout@v4`

This PR removes both lines, keeping only the base branch fetch which `diff-cover` actually needs for comparison.

## Review & Testing Checklist for Human

- [ ] Verify that `diff-cover` still works correctly with just the base branch fetch — it compares `origin/$BASE` against `HEAD`, and `HEAD` is already set by `actions/checkout@v4`
- [ ] Re-run the failing `candidate-backend` CI job after merging: https://github.com/doctariDev/candidate-backend/actions/runs/26451941824/job/78098964289

### Notes

This makes the action resilient to deleted branches (common when re-running CI after a PR branch has been cleaned up).

Link to Devin session: https://app.devin.ai/sessions/92af84e6f09e41ec8067c58c26aa354c
Requested by: @kkhaidukov