### PR TITLE
fix: remove head branch fetch and checkout that fails on dirty worktree

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -59,8 +59,6 @@ runs:
           shell: bash
           run: |
               git fetch origin ${{ github.event.pull_request.base.ref }}
-              git fetch origin ${{ github.event.pull_request.head.ref }}
-              git checkout ${{ github.event.pull_request.head.sha }}
 
         - name: Check coverage
           if: github.event_name == 'pull_request' && (inputs.diff-lines-threshold == 0 || steps.check-lines.outputs.skip-coverage != 'true')


### PR DESCRIPTION
## Summary

Removes the `git fetch origin <head-ref>` and `git checkout <head-sha>` commands from the "Fetch base branch for comparison" step.

**Problem:** When a consuming workflow runs `yarn install` (or similar) before this action, `yarn.lock` gets modified. The subsequent `git checkout` of the PR head SHA fails because git refuses to overwrite the dirty file:

```
error: Your local changes to the following files would be overwritten by checkout:
    yarn.lock
Please commit your changes or stash them before you switch branches.
```

This has been breaking the "Check test coverage" job on every PR in `candidate-backend` since the Node 24 upgrade (April 2026), because Node 24's yarn now modifies `yarn.lock` during install on merge commits.

**Why the checkout is unnecessary:** `actions/checkout@v4` on `pull_request` events checks out a merge commit that already contains the PR's changes on top of the base branch. `diff-cover --compare-branch=origin/master` therefore produces the correct diff without needing to switch to the PR head commit.

A previous attempt to fix this with `git checkout -f` (commit 906d4b1) was merged and reverted within 17 minutes.

## Review & Testing Checklist for Human

- [ ] Merge this PR, then re-run the "Check test coverage" job on an open `candidate-backend` PR (e.g. [#5339](https://github.com/doctariDev/candidate-backend/pull/5339)) to verify it passes
- [ ] Verify the coverage report comment is correctly posted on the PR

### Notes

The only remaining git command in the step is `git fetch origin <base-ref>`, which is needed so `diff-cover` can compare against `origin/master`.

Link to Devin session: https://app.devin.ai/sessions/91f6c3e0d63549379d22705dda69e5fd
Requested by: @andrmoel